### PR TITLE
Added httpClient error handling

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -75,7 +75,14 @@ var requestMethods = {
     }
   },
   _getClient: function(port, host) {
-    return this.options.client || http.createClient(port, host);
+    var self = this;
+    client =  this.options.client || http.createClient(port, host);
+    // handle any errors which the client may throw and emit them to our own error handler
+    // otherwise node will throw an exception.
+    client.on("error", function(err) {
+      self._respond("error", "", err);
+    });
+    return client;
   },
   _responseHandler: function(response) {
     var self = this;


### PR DESCRIPTION
Added an on "error" handler for httpClient which will push the error through to the registered error handler as part of restler.

Otherwise the error will not get handled and node will throw an exception on things like "Connection Refused" etc.
