### PR TITLE
Bug fixed: File uploads garbled if more than 1 restler.post done simultaneously

### DIFF
--- a/lib/multipartform.js
+++ b/lib/multipartform.js
@@ -109,7 +109,7 @@ Part.prototype = {
   	  fs.open(this.value.path, "r", 0666, function (err, fd) { 
     	  if (err) throw err; 
     	  
-  		  position = 0;
+  		  var position = 0;
   		  
   	    (function reader () {
   	      fs.read(fd, 1024 * 4, position, "binary", function (er, chunk) {


### PR DESCRIPTION
Bug fixed: File upload failing if more than 1 restler.post done simultaneously

position should be a local variable.
