### PR TITLE
JSON parser throws exception if JSON is malformed

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -205,7 +205,10 @@ var parsers = {
     callback(data);
   },
   json: function(data, callback) {
-    callback(data && JSON.parse(data));
+    try {
+      data = JSON.parse(data);
+    } catch(e) {}
+    callback(data);
   }
 }
 


### PR DESCRIPTION
Currently, the parser just assumes that the input is valid JSON.
Great library BTW.
