### PR TITLE
'Content-Length' header add at options.data is string

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ Example usage
       sys.p(data);
     });
 
+    // the JSON post
+    rest.post('http://example.com/action', {
+      data: JSON.stringify({ id: 334 }),
+    }).on('complete', function(data, response) {
+      // you can get at the raw response like this...
+    });
+
     
 Running the tests
 -----------------

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -46,6 +46,11 @@ function Request(uri, options) {
       this.headers['Content-Type'] = 'application/x-www-form-urlencoded';
       this.headers['Content-Length'] = this.options.data.length;
     }
+    if(typeof this.options.data == 'string') {
+      var buffer = new Buffer(this.options.data, this.options.encoding || 'utf8');
+      this.options.data = buffer;
+      this.headers['Content-Length'] = buffer.length;
+    }
   }
   
   var proto = (this.url.protocol == 'https:') ? https : http;

--- a/test/restler.js
+++ b/test/restler.js
@@ -146,3 +146,23 @@ helper.testCase('Redirect Tests', helper.redirectServer, {
     });
   }
 });
+
+helper.testCase('Content-Length Tests', helper.contentLengthServer, {
+  testRequestHeaderIncludesContentLengthWithJSONData: function(host, test){
+    var jsonString = JSON.stringify({ greeting: 'hello world' });
+    rest.post(host, {
+      data: jsonString
+    }).on('complete', function(data){
+      test.equal(26, data, 'should set content-length');
+    });
+  },
+  testJSONMultibyteContentLength: function (host, test){
+    var multibyteData = JSON.stringify({ greeting: 'こんにちは世界' });
+    rest.post(host, {
+      data: multibyteData
+    }).on('complete', function(data) {
+      test.notEqual(22, data, 'should unicode string length');
+      test.equal(36, data, 'should byte-size content-length');
+    });
+  }
+});

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -84,6 +84,25 @@ exports.redirectServer = function() {
   return ["http://localhost:" + port, server];
 }
 
+exports.contentLengthServer = function (){
+  var port = exports.port++;
+
+  var server = http.createServer(function(request, response){
+    response.writeHead(200, { 'Content-Type': 'text/plain' });
+    if('content-length' in request.headers){
+      response.write(request.headers['content-length']);
+    } else {
+      response.write('content-length isnot set');
+    }
+
+    response.end();
+    server.close();
+  });
+
+  server.listen(port, 'localhost');
+  return ['http://localhost:' + port, server];
+};
+
 exports.port = 7000;
 
 exports.testCase = function(caseName, serverFunc, tests) {


### PR DESCRIPTION
the 'Content-Length' header at typeof(options.data is string) w/ byte sized 'Content-Length' header(consider multi-byte)
when a use exchanges JSON data by string

added example to README
