### PR TITLE
Empty server response causes "Unexpected end of input" exception

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -213,7 +213,7 @@ var parsers = {
     callback(data);
   },
   json: function(data, callback) {
-    callback(data && JSON.parse(data));
+    callback(data && data.length > 1 && JSON.parse(data));
   }
 }
 


### PR DESCRIPTION
This adds a simple check to the data length in addition to the existence of data when parsing JSON. Rails PUT operations return an empty string, which causes this exception.
