### PR TITLE
Emit response allow restler's users to work with stream ;) 

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -205,6 +205,7 @@ mixin(Request.prototype, {
   _makeRequest: function() {
     var self = this;
     this.request.on('response', function(response) {
+      self.emit('response', response);
       self._responseHandler(response);
     }).on('error', function(err) {
       if (!self.aborted) {


### PR DESCRIPTION
I just needed to get response stream (to save [large] image files).
I was using restler to get some JSON API and did'nt want to use plain http just for saving a file....
The patch is very simple. 
