### PR TITLE
Added json method to services

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -450,6 +450,9 @@ mixin(Service.prototype, {
   post: function(path, options) {
     return post(this._url(path), this._withDefaults(options));
   },
+  json: function(method, path, data, options) {
+    return json(this._url(path), data, this._withDefaults(options), method);
+  },
   del: function(path, options) {
     return del(this._url(path), this._withDefaults(options));
   },


### PR DESCRIPTION
json method saves the user from setting options on a regular request as

```
{ data: JSON.stringify(data} }
```
