### PR TITLE
Make multipart.sizeOf work with numeric values

### DIFF
--- a/lib/multipartform.js
+++ b/lib/multipartform.js
@@ -87,6 +87,8 @@ Part.prototype = {
   	  valueSize = this.value.fileSize;
   	} else if (this.value.data) {
   	  valueSize = this.value.data.length;
+        } else if (typeof this.value === 'number') {
+          valueSize = this.value.toString().length;
   	} else {
   	  valueSize = this.value.length;
   	}


### PR DESCRIPTION
Currently if a value is numeric part.sizeOf() returns NaN, this fixes it (needed to fix #64).
