### PR TITLE
workaround for not having the entire callback chain inside a try-catch block

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -368,10 +368,12 @@ var parsers = {
   },
   json: function(data, callback) {
     if (data && data.length) {
+      var err;
       try {
         data = JSON.parse(data);
         err = null;
-      } catch (err) {
+      } catch (caughtErr) {
+        err = caughtErr;
         err.message = 'Failed to parse JSON body: ' + err.message;
       }
       callback(err, data);


### PR DESCRIPTION
Because the initial callback execution in the JSON parser was wrapped in a try-catch block, all of the errors thrown from the callbacks that were executed from within the initial callback caused this try-catch block to handle the error. Note that the error that was thrown (in a callback or even further below the stacktrace), was far from being an issue with parsing the JSON that came from an API.
