### PR TITLE
Multiple 'complete' event in JSON parsing

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -1,4 +1,6 @@
 var sys       = require('util');
+var util      = require('util');
+var events    = require('events');
 var http      = require('http');
 var https     = require('https');
 var url       = require('url');
@@ -88,7 +90,7 @@ function Request(uri, options) {
   this._makeRequest();
 }
 
-Request.prototype = new process.EventEmitter();
+util.inherits(Request, events.EventEmitter);
 
 mixin(Request.prototype, {
   _isRedirect: function(response) {


### PR DESCRIPTION
I remove from callback() from try..catch.. block. Because, when the error was thrown in (user's) callback, your try...catch will catch it.

Try with this code...

var rest = require('./restler');
var express = require('express');
var count = 0;

var app = express();
app.listen(8083);
app.get('/',function(req,res) { res.send({'Hello':'World'});})

rest.get('http://localhost:8083').on('complete',function(res) {

  console.log('count:'+count++)
  console.log(res)

  //Make..error
  res.forEach();
})
