### PR TITLE
Allow to pass agent to the http/https node libraries based on the node API

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -83,6 +83,7 @@ function Request(uri, options) {
     path: this._fullPath(),
     method: this.options.method,
     headers: this.headers
+    agent: this.options.agent,
   });
   
   this._makeRequest();


### PR DESCRIPTION
Hey,

I've added an option to pass a custom agent to the http/https calls. Can you take a look at it, please?
http://nodejs.org/api/http.html#http_http_request_options_callback
http://nodejs.org/api/https.html#https_https_request_options_callback
## Thank you!

Vadim
