### PR TITLE
Don't override header and query defaults when using services; fix retry bug that garbled data on subsequent requests

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -370,12 +370,14 @@ var parsers = {
   },
   json: function(data, callback) {
     if (data && data.length) {
+      var json = null, 
+          err = null;
       try {
-        callback(null, JSON.parse(data));
-      } catch (err) {
+        json = JSON.parse(data);
+      }  catch (err) {
         err.message = 'Failed to parse JSON body: ' + err.message;
-        callback(err, null);
       }
+      callback(err, json);
     } else {
       callback(null, null);
     }


### PR DESCRIPTION
When using services that included defaults for headers and query parameters, they would get overridden if you specified additional parameters in a specific request.

When retrying failed requests that included post data in string format, the string would get garbled in each subsequent request.
