### PR TITLE
Support for OAuth/Bearer authentication

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -1,4 +1,5 @@
-var sys       = require('util');
+var util      = require('util');
+var events    = require("events");
 var http      = require('http');
 var https     = require('https');
 var url       = require('url');
@@ -25,6 +26,7 @@ function mixin(target, source) {
 }
 
 function Request(uri, options) {
+  events.EventEmitter.call(this);
   this.url = url.parse(uri);
   this.options = options;
   this.headers = {
@@ -88,7 +90,7 @@ function Request(uri, options) {
   this._makeRequest();
 }
 
-Request.prototype = new process.EventEmitter();
+util.inherits(Request, events.EventEmitter);
 
 mixin(Request.prototype, {
   _isRedirect: function(response) {
@@ -304,7 +306,7 @@ function request(url, options) {
   var request = new Request(url, options);
   request.on('error', function() {});
   process.nextTick(request.run.bind(request));
- 	return request;
+  return request;
 }
 
 function get(url, options) {


### PR DESCRIPTION
More and more REST service need to authenticate via OAUTH/Bearer access tokens.
These patch needs only one option:

```
this.options.accessToken = '...'
```
