### PR TITLE
Fix restler.Request inheritance of EventEmitter for 0.10.x

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -3,6 +3,7 @@ var http      = require('http');
 var https     = require('https');
 var url       = require('url');
 var qs        = require('querystring');
+var events    = require('events');
 var multipart = require('./multipartform');
 var zlib      = null;
 var Iconv     = null;
@@ -88,7 +89,7 @@ function Request(uri, options) {
   this._makeRequest();
 }
 
-Request.prototype = new process.EventEmitter();
+sys.inherits(Request, events.EventEmitter);
 
 mixin(Request.prototype, {
   _isRedirect: function(response) {


### PR DESCRIPTION
Fixed, as previously proposed by others, inheritance of `events.EventEmitter` for `restler.Request`, this time with as little code changes as possible. I verified that `test/all.js` now passes against node `0.6.19`, `0.8.23` and `0.10.4`. 
