### PR TITLE
Fix Data object support

### DIFF
--- a/lib/multipartform.js
+++ b/lib/multipartform.js
@@ -67,6 +67,7 @@ Part.prototype = {
     if (this.value.data) {
 	    header = "Content-Disposition: form-data; name=\"" + this.name + 
   	            "\"; filename=\"" + this.value.filename + "\"\r\n" +
+  	            "Content-Length: " + this.value.data.length + "\r\n" +	
   	            "Content-Type: " + this.value.contentType;
  	  } else if (this.value instanceof File) {
   	  header = "Content-Disposition: form-data; name=\"" + this.name + 
@@ -128,7 +129,8 @@ Part.prototype = {
   	    })(); // reader() 
   	  });
      } else if (this.value instanceof Data) {
-  	  stream.write(this.value.data + "\r\n");
+  	  stream.write(this.value.data);
+  	  stream.write("\r\n");
   	  callback();
      } else {
   	  stream.write(this.value + "\r\n");


### PR DESCRIPTION
Restler supplies a Data object, but it is improperly handled when writing to the stream.
1. Omission of an 'else' results in the metadata associated with the object not being written in the part header.
2. Omission of handling when writing the value results in "[Object object]" being written to the stream.

This corrects these two issues.
