### PR TITLE
Allow empty-password authorization header

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -109,7 +109,7 @@ mixin(Request.prototype, {
       this.options.password = authParts[1];
     }
     
-    if (this.options.username && this.options.password) {
+    if (this.options.username && this.options.password !== undefined) {
       var b = new Buffer([this.options.username, this.options.password].join(':'));
       this.headers['Authorization'] = "Basic " + b.toString('base64');
     }


### PR DESCRIPTION
Including Authorization header if an empty password (not undefined) is specified to handle the case where an api key is passed via username but no password is required (for example, asana.com)
