### PR TITLE
Added missing documentation for PATCH HTTP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Create a DELETE request.
 
 Create a HEAD request.
 
+### patch(url, options)
+
+Create a PATCH request.
+
 ### json(url, data, options)
 
 Send json `data` via GET method.


### PR DESCRIPTION
Added missing documentation for PATCH HTTP method.

I'm using the library and I need to use a PATH method. After read the docs, I have seen the PATCH method is not present, so I reviewed the code I can see it's supported (as I expected, obviously), so just add it in order to prevent future surprises and doubts to another developers.
