### PR TITLE
Move to a purejs implementation of iconv

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -6,7 +6,7 @@ var util      = require('util'),
     qs        = require('qs'),
     multipart = require('./multipartform'),
     zlib      = require('zlib'),
-    Iconv     = require('iconv').Iconv;
+    iconv     = require('iconv-lite');
 
 function mixin(target, source) {
   source = source || {};
@@ -176,8 +176,7 @@ mixin(Request.prototype, {
         charset = charset[1].trim().toUpperCase();
         if (charset != 'UTF-8') {
           try {
-            var iconv = new Iconv(charset, 'UTF-8//TRANSLIT//IGNORE');
-            return iconv.convert(body);
+            return iconv.decode(body, charset);
           } catch (err) {}
         }
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "qs": "0.6.6",
     "xml2js": "0.4.0",
     "yaml": "0.2.3",
-    "iconv": "2.0.7"
+    "iconv-lite": "0.2.11"
   },
   "devDependencies": {
     "nodeunit": "0.8.2"

--- a/test/restler.js
+++ b/test/restler.js
@@ -3,9 +3,7 @@ var rest   = require('../lib/restler'),
     util    = require('util'),
     path   = require('path'),
     fs     = require('fs'),
-    crypto = require('crypto'),
-    zlib = require('zlib'),
-    Iconv = require('iconv').Iconv;
+    crypto = require('crypto');
 
 var port = 9000;
 var hostname = 'localhost';
@@ -587,14 +585,13 @@ module.exports['Deserialization'] = {
 
 };
 
-if (Iconv) {
-  module.exports['Deserialization']['Should correctly convert charsets '] = function(test) {
-    rest.get(host + '/charset').on('complete', function(data) {
-      test.equal(data, 'абвгдеёжзийклмнопрстуфхцчшщъыьэюя');
-      test.done();
-    });
-  };
-}
+
+module.exports['Deserialization']['Should correctly convert charsets '] = function(test) {
+  rest.get(host + '/charset').on('complete', function(data) {
+    test.equal(data, 'абвгдеёжзийклмнопрстуфхцчшщъыьэюя');
+    test.done();
+  });
+};
 
 
 function redirectResponse(request, response) {


### PR DESCRIPTION
A purejs implementation of iconv removes our dependency on needing build tools when installing restler.
