### PR TITLE
Don't execute callback within a try catch

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -397,7 +397,9 @@ var parsers = {
         err.message = 'Failed to parse JSON body: ' + err.message;
         callback(err, null);
       }
-      callback(null, parsedData);
+      if (parsedData !== undefined) {
+        callback(null, parsedData);
+      }
     } else {
       callback(null, null);
     }


### PR DESCRIPTION
Minor update to not execute callbacks within the try/catch block of the JSON.parse call.
