### PR TITLE
Don't call response.setEncoding when it isn't defined

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -135,7 +135,7 @@ mixin(Request.prototype, {
       var body = '';
 
       // When using browserify, response.setEncoding is not defined
-      if (response.setEncoding !== null)
+      if (typeof response.setEncoding == 'function')
         response.setEncoding('binary');
 
       response.on('data', function(chunk) {

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -134,7 +134,9 @@ mixin(Request.prototype, {
     } else {
       var body = '';
 
-      response.setEncoding('binary');
+      // When using browserify, response.setEncoding is not defined
+      if (response.setEncoding !== null)
+        response.setEncoding('binary');
 
       response.on('data', function(chunk) {
         body += chunk;


### PR DESCRIPTION
This pull request checks to see if setEncoding is defined on response. If it isn't, it won't attempt to call it.

This would fix #161. Comments or concerns welcome.