### PR TITLE
Adding the ability to add a custom https agent.

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -71,6 +71,7 @@ function Request(uri, options) {
   }
 
   var proto = (this.url.protocol == 'https:') ? https : http;
+  var agent = (this.options.agent) ? this.options.agent : undefined;
 
   this.request = proto.request({
     host: this.url.hostname,
@@ -78,7 +79,8 @@ function Request(uri, options) {
     path: this._fullPath(),
     method: this.options.method,
     headers: this.headers,
-    rejectUnauthorized: this.options.rejectUnauthorized
+    rejectUnauthorized: this.options.rejectUnauthorized,
+    agent: agent
   });
 
   this._makeRequest();


### PR DESCRIPTION
We have a requirement such that we need to make non standard HTTPS calls. We need to alter the https agent and pass information on where to read the cert, ca and cert files are not provided by the connection.

An example use case is as follows

```
options = {
        hostname: parsed.hostname,
        port: parsed.port,
        path: parsed.path,
        method: 'POST',
        key: fs.readFileSync('/var/www/apps/custom/current/config/certs/custom.key'),
        cert: fs.readFileSync('/var/www/apps/custom/current/config/certs/custom.crt')
        ca: fs.readFileSync('/var/www/apps/custom/current/config/certs/customca.crt')
 }
agent = new https.Agent(options)

restler.post(@mtUrl, {data: params, agent: agent}).on 'success', function(data, resp) {
  // bla bla
})
```

The pull request is super simple so would be excellent if you could merge it in.
