### PR TITLE
Restler reports different behavior on different platforms when the target server doesn't exist (isn't running).

### DIFF
--- a/test/restler.js
+++ b/test/restler.js
@@ -728,3 +728,20 @@ module.exports['Timeout'] = {
     });
   }
 };
+
+module.exports['MissingServer'] = {
+  // no setUp or tearDown: the server isn't running
+
+  'will timeout within given time': function(test) {
+    rest.get(host + '/timeout', {timeout: 50})
+    .on('timeout', function () {
+      test.ok(true, 'timeout endpoint is 100ms and timeout was 50ms');
+      test.done();
+    })
+    .on('complete', function () {
+      test.ok(err.code === 'ECONNREFUSED', 'timeout is reported as ECONNREFUSED');
+      test.ok(false, 'should not emit complete event');
+      test.done();
+    });
+  }
+};


### PR DESCRIPTION
On win32, this test passes: restler passes a connection timeout. On non-win32, this test fails: restler returns an 'ECONNREFUSED' error.  See https://gist.github.com/robrich/74bff4b51358a3470160 for similar experiments on native http.request's different behavior when the target server doesn't exist.
