### PR TITLE
don't submit content-length header on GET requests

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -65,7 +65,7 @@ function Request(uri, options) {
       this.options.data = buffer;
       this.headers['Content-Length'] = buffer.length;
     }
-    if (!this.options.data) {
+    if (!this.options.data && this.options.method !== 'GET') {
       this.headers['Content-Length'] = 0;
     }
   }


### PR DESCRIPTION
According to the HTTP spec the presence of the 'Content-Length' header signals that there is a message body (even if the length is 0).  Also, since according to the spec, GET requests do not allow message bodies and therefore should not include the 'Content-Length' header.

From RFC 2616, Section 4.3:

"The presence of a message-body in a request is signaled by the
   inclusion of a Content-Length or Transfer-Encoding header field in
   the request's message-headers. A message-body MUST NOT be included in
   a request if the specification of the request method (section 5.1.1)
   does not allow sending an entity-body in requests."
