### PR TITLE
New option: forceResponseCharset

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -174,7 +174,7 @@ mixin(Request.prototype, {
     var charset = response.headers['content-type'];
     if (charset || this.options.forceResponseCharset) {
       if (this.options.forceResponseCharset) {
-        charset = this.options.forceResponseCharset;
+        charset = [null, this.options.forceResponseCharset];
       }
       else {
         charset = /\bcharset=(.+)(?:;|$)/i.exec(charset);


### PR DESCRIPTION
# forceResponseCharset

This option allows user to force the charset of the response. This is useful when no charset is specified in response.
# Example usage

```
rest.post('http://twaud.io/api/v1/users/danwrong.json', {
  forceResponseCharset: 'iso-8859-15'
}).on('complete', function(data) {
  console.log(data[0].message); // auto convert to object
});
```
