### PR TITLE
Permit Buffer and binary string as options.data.

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -55,19 +55,14 @@ function Request(uri, options) {
         console.log("Building multipart request without Content-Length header, please specify all file sizes");
     }
   } else {
-    if (typeof this.options.data == 'object') {
-      this.options.data = qs.stringify(this.options.data);
+    if (!Buffer.isBuffer(this.options.data) && typeof this.options.data == 'object') {
       this.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-      this.headers['Content-Length'] = this.options.data.length;
+      this.options.data = this._requestStringToBuffer(qs.stringify(this.options.data));
     }
-    if (typeof this.options.data == 'string') {
-      var buffer = new Buffer(this.options.data, this.options.encoding || 'utf8');
-      this.options.data = buffer;
-      this.headers['Content-Length'] = buffer.length;
+    else if (typeof this.options.data == 'string') {
+      this.options.data = this._requestStringToBuffer(this.options.data);
     }
-    if (!this.options.data) {
-      this.headers['Content-Length'] = 0;
-    }
+    this.headers["Content-Length"] =  this.options.data ? this.options.data.length : 0;
   }
 
   var proto = (this.url.protocol == 'https:') ? https : http;
@@ -260,7 +255,7 @@ mixin(Request.prototype, {
       });
     } else {
       if (this.options.data) {
-        this.request.write(this.options.data.toString(), this.options.encoding || 'utf8');
+        this.request.write(this.options.data);
       }
       this.request.end();
     }
@@ -304,6 +299,9 @@ mixin(Request.prototype, {
       setTimeout(fn, timeout);
     }
     return this;
+  },
+  _requestStringToBuffer: function(string) {
+      return new Buffer(string, this.options.encoding || 'utf8');
   }
 });
 


### PR DESCRIPTION
Prior to this change Buffer was subjected to stringify as it matched the
'object' typeof test.  binary string also ended up corrupt.  This change
ensures we're done with encoding by the time we write to the request
and adds some tests that previously failed.
