### PR TITLE
Fix an encoding issue

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -260,7 +260,7 @@ mixin(Request.prototype, {
       });
     } else {
       if (this.options.data) {
-        this.request.write(this.options.data.toString(), this.options.encoding || 'utf8');
+        this.request.write(this.options.data, this.options.encoding || 'utf8');
       }
       this.request.end();
     }


### PR DESCRIPTION
this.options.data.toString() assumes it's UTF-8 and ignore the provided encoding.