### PR TITLE
avoid re-encoding request body on retry

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -58,8 +58,8 @@ function Request(uri, options) {
     if (typeof this.options.data == 'object') {
       if (!(this.options.data instanceof Buffer)) {
         this.options.data = qs.stringify(this.options.data);
+        this.headers['Content-Type'] = 'application/x-www-form-urlencoded';
       }
-      this.headers['Content-Type'] = 'application/x-www-form-urlencoded';
       this.headers['Content-Length'] = this.options.data.length;
     }
     if (typeof this.options.data == 'string') {


### PR DESCRIPTION
This avoids stringifying an already encoded request body (on retry) which exponentially grows the request body size, and causes memory problems/failed requests.
