### PR TITLE
restler can now also handle data which is not encoded (e.g. images)

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -134,17 +134,15 @@ mixin(Request.prototype, {
         self._fireError(err, response);
       }
     } else {
-      var body = '';
-
-      response.setEncoding('binary');
+      var body = new Buffer('');
 
       response.on('data', function(chunk) {
-        body += chunk;
+        body = Buffer.concat([body, new Buffer(chunk)]);
       });
 
       response.on('end', function() {
         response.rawEncoded = body;
-        self._decode(new Buffer(body, 'binary'), response, function(err, body) {
+        self._decode(body, response, function(err, body) {
           if (err) {
             self._fireError(err, response);
             return;


### PR DESCRIPTION
Hello there,

I am using Restler to fetch data from the Dropbox api. While textfiles etc worked flawlessly, data which has no encoding was acting up (images). With this small change, restler can now also handle data which has no encoding.

Kind Regards
