### PR TITLE
trim incoming data before trying to parse it as json to make sure there ...

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -395,7 +395,7 @@ var parsers = {
     }
   },
   json: function(data, callback) {
-    if (data && data.length) {
+    if (data && data.trim().length) {
       var parsedData;
       try {
         parsedData = JSON.parse(data);

--- a/test/restler.js
+++ b/test/restler.js
@@ -388,6 +388,10 @@ function dataResponse(request, response) {
       response.writeHead(200, { 'content-type': 'application/yaml' });
       response.end('{Чебурашка');
       break;
+    case '/empty-json-trim':
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(' ');
+      break;
     case '/abort':
       setTimeout(function() {
         response.writeHead(200);
@@ -589,6 +593,20 @@ module.exports['Deserialization'] = {
       test.ok(false, 'should not have got here');
     }).on('fail', function() {
       test.ok(false, 'should not have got here');
+    });
+  },
+
+  'Should treat trimmed empty data as a valid response': function(test) {
+    test.expect(2);
+    rest.get(host + '/empty-json-trim').on('complete', function(err, response) {
+      test.equal(response.raw, ' ', 'should be " ", got: ' + util.inspect(response.raw));
+      test.done();
+    }).on('error', function(err) {
+      test.ok(false, 'should not have triggered an error');
+    }).on('fail', function() {
+      test.ok(false, 'should not have triggered a fail');
+    }).on('success', function() {
+      test.ok(true, 'should have triggered a success');
     });
   },
 


### PR DESCRIPTION
...is something to parse.

As context, I need this in an integration with the GetHarvest API, where they use restler but return " " (empty string with space) in their response. Ideally I would prefer that they do the fix on their side, however since it is not open source I feel like this would take forever. I have added the fix and included a test.

issue: https://github.com/danwrong/restler/issues/207

thanks!
