### PR TITLE
New option to specify http agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Also you can use `json()` and `postJson()` methods.
 * `followRedirects` If set will recursively follow redirects. Defaults to `true`.
 * `timeout` If set, will emit the timeout event when the response does not return within the said value (in ms)
 * `rejectUnauthorized` If true, the server certificate is verified against the list of supplied CAs. An 'error' event is emitted if verification fails. Verification happens at the connection level, before the HTTP request is sent. Default true.
-
+* `agent` [HTTP Agent][http-agent-doc] instance to use. If not defined [globalAgent][http-global-agent-doc] will be used. If false opts out of connection pooling with an Agent, defaults request to Connection: close.
 
 Example usage
 -------------
@@ -221,3 +221,6 @@ rest.putJson('http://example.com/action', jsonData).on('complete', function(data
 TODO
 ----
 * What do you need? Let me know or fork.
+
+[http-agent-doc]: https://nodejs.org/api/http.html#http_class_http_agent
+[http-global-agent-doc]: https://nodejs.org/api/http.html#http_http_globalagent 

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -78,7 +78,8 @@ function Request(uri, options) {
     path: this._fullPath(),
     method: this.options.method,
     headers: this.headers,
-    rejectUnauthorized: this.options.rejectUnauthorized
+    rejectUnauthorized: this.options.rejectUnauthorized,
+    agent: this.options.agent
   });
 
   this._makeRequest();


### PR DESCRIPTION
Sometime it is necessary to control request pooling. Node.js Request supports ability to specify custom HTTP Agent:
https://nodejs.org/api/http.html#http_http_request_options_callback
https://nodejs.org/api/http.html#http_new_agent_options