### PR TITLE
Prevent options object from being mutated. Fixes #230.

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -310,8 +310,8 @@ mixin(Request.prototype, {
   }
 });
 
-function shortcutOptions(options, method) {
-  options = options || {};
+function shortcutOptions(opts, method) {
+  var options = mixin({}, opts);
   options.method = method;
   options.parser = (typeof options.parser !== "undefined") ? options.parser : parsers.auto;
   parsers.xml.options = (typeof options.xml2js == 'undefined') ? {} : options.xml2js;
@@ -349,8 +349,8 @@ function head(url, options) {
   return request(url, shortcutOptions(options, 'HEAD'));
 }
 
-function json(url, data, options, method) {
-  options = options || {};
+function json(url, data, opts, method) {
+  var options = mixin({}, opts);
   options.parser = (typeof options.parser !== "undefined") ? options.parser : parsers.auto;
   options.headers = options.headers || {};
   options.headers['content-type'] = 'application/json';

--- a/test/restler.js
+++ b/test/restler.js
@@ -641,6 +641,24 @@ module.exports['Deserialization'] = {
     }).on('fail', function() {
       test.ok(false, 'should not have got here');
     });
+  },
+
+  'Should parse JSON without mutating options': function(test) {
+    var options = {};
+    rest.get(host + '/json', options).on('complete', function(data) {
+      test.equal(data.ok, true, 'returned: ' + util.inspect(data));
+      test.deepEqual({}, options, 'mutated: ' + util.inspect(options));
+      test.done();
+    });
+  },
+
+  'Should post and parse JSON without mutating options': function(test) {
+    var obj = { secret : 'very secret string' }, options = {};
+    rest.json(host + '/push-json', obj, options, 'POST').on('complete', function(data) {
+      test.equal(obj.secret, data.secret, 'returned: ' + util.inspect(data));
+      test.deepEqual({}, options, 'mutated: ' + util.inspect(options));
+      test.done();
+    });
   }
 
 };


### PR DESCRIPTION
Restler freely mutates the contents of the options object, causing issues such as #230. This PR uses the already available mixin function to prevent this from happening, allowing multiple calls utilizing the same options object to function. I added two new tests as well, which did not pass before I made the change.

A possible regression due to this change could be a case where someone calls restler.get(url, options) followed by restler.request(url, options). Before this change was made, .get would have populated the options object and made it usable by the .request function, after this change, options will no longer be mutated by the call to .get so the subsequent .request may fail if the options were not sufficiently set in the first place. But I think the good outweighs the bad here, especially for POST/PUT/PATCH functions.
