### PR TITLE
modify argument of mode for es2015 strict compatibility, fixes #234

### DIFF
--- a/lib/multipartform.js
+++ b/lib/multipartform.js
@@ -109,7 +109,7 @@ Part.prototype = {
 	
   	//Now write out the body of the Part
     if (this.value instanceof File) {
-  	  fs.open(this.value.path, "r", 0666, function (err, fd) { 
+  	  fs.open(this.value.path, "r", "0666", function (err, fd) {
     	  if (err) throw err; 
     	  
   		  var position = 0;

--- a/test/restler.js
+++ b/test/restler.js
@@ -110,7 +110,7 @@ module.exports['Basic'] = {
     });
   },
 
-  'Should GET withouth path': function(test) {
+  'Should GET without path': function(test) {
     rest.get(host).on('complete', function(data) {
       test.re(data, /^GET \//, 'should hit /');
       test.done();


### PR DESCRIPTION
This fixes #234 _SyntaxError: Octal literals are not allowed in strict mode_.

The fix uses an option of supplying mode in a valid data type - string. This can be referred in [source code](https://github.com/nodejs/node-v0.x-archive/blob/c7f424e44b7e61b89f91cd344599c3d1cdfb88fe/lib/fs.js#L422) for `fs.open()`. Keeping the argument as string makes the script pass es2015 strict validations and hence can be used by dependent packages like [sendwithus](https://github.com/sendwithus/sendwithus_nodejs) in wider environments like node with es2015 strict mode.
