### PR TITLE
added option to disble decoding of gzip and deflate: disable_decoding

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -147,10 +147,6 @@ mixin(Request.prototype, {
 
       response.on('end', function() {
         response.rawEncoded = body;
-        if( self.options.disable_decoding){
-          self._fireSuccess(body, response);
-        }
-        else{
           self._decode(new Buffer(body, 'binary'), response, function(err, body) {
             if (err) {
               self._fireError(err, response);
@@ -166,7 +162,6 @@ mixin(Request.prototype, {
               }
             });
           });
-        }
       });
     }
   },

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -465,8 +465,14 @@ try {
   parsers.auto.matchers['application/xml'] = parsers.xml;
 } catch(e) { }
 
-var decoders = {};
-
+var decoders = {
+  gzip: function(buf, callback) {
+    zlib.gunzip(buf, callback);
+  },
+  deflate: function(buf, callback) {
+    zlib.inflate(buf, callback);
+  }
+};
 
 function Service(defaults) {
   if (defaults.baseURL) {

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -154,7 +154,7 @@ mixin(Request.prototype, {
           }
           response.raw = body;
           body = self._iconv(body, response);
-          self._encode(body, response, function(err, body) {
+          self._encode(body, response, self.options.disable_decoding, function(err, body) {
             if (err) {
               self._fireError(err, response);
             } else {
@@ -190,13 +190,13 @@ mixin(Request.prototype, {
     }
     return body;
   },
-  _encode: function(body, response, callback) {
+  _encode: function(body, response, disableDecoding, callback) {
     var self = this;
     if (self.options.decoding == 'buffer') {
       callback(null, body);
     } else {
       body = body.toString(self.options.decoding);
-      if (self.options.parser) {
+      if (!(disableDecoding === true) && self.options.parser) {
         self.options.parser.call(response, body, callback);
       } else {
         callback(null, body);

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -147,21 +147,26 @@ mixin(Request.prototype, {
 
       response.on('end', function() {
         response.rawEncoded = body;
-        self._decode(new Buffer(body, 'binary'), response, function(err, body) {
-          if (err) {
-            self._fireError(err, response);
-            return;
-          }
-          response.raw = body;
-          body = self._iconv(body, response);
-          self._encode(body, response, function(err, body) {
+        if( self.options.disable_decoding){
+          self._fireSuccess(body, response);
+        }
+        else{
+          self._decode(new Buffer(body, 'binary'), response, function(err, body) {
             if (err) {
               self._fireError(err, response);
-            } else {
-              self._fireSuccess(body, response);
+              return;
             }
+            response.raw = body;
+            body = self._iconv(body, response);
+            self._encode(body, response, function(err, body) {
+              if (err) {
+                self._fireError(err, response);
+              } else {
+                self._fireSuccess(body, response);
+              }
+            });
           });
-        });
+        }
       });
     }
   },

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -468,14 +468,7 @@ try {
   parsers.auto.matchers['application/xml'] = parsers.xml;
 } catch(e) { }
 
-var decoders = {
-  gzip: function(buf, callback) {
-    zlib.gunzip(buf, callback);
-  },
-  deflate: function(buf, callback) {
-    zlib.inflate(buf, callback);
-  }
-};
+var decoders = {};
 
 
 function Service(defaults) {

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -146,15 +146,20 @@ mixin(Request.prototype, {
       });
 
       response.on('end', function() {
+        if(self.options.disable_decoding === true){
+          self._fireSuccess(body,response);
+          return;
+        }
+
         response.rawEncoded = body;
-        self._decode(new Buffer(body, 'binary'), response, self.options.disable_decoding, function(err, body) {
+        self._decode(new Buffer(body, 'binary'), response, function(err, body) {
           if (err) {
             self._fireError(err, response);
             return;
           }
           response.raw = body;
           body = self._iconv(body, response);
-          self._encode(body, response, self.options.disable_decoding, function(err, body) {
+          self._encode(body, response, function(err, body) {
             if (err) {
               self._fireError(err, response);
             } else {
@@ -165,13 +170,11 @@ mixin(Request.prototype, {
       });
     }
   },
-  _decode: function(body, response, disableDecoding, callback) {
+  _decode: function(body, response, callback) {
     var decoder = response.headers['content-encoding'];
-    if (!(disableDecoding === true) && decoder in decoders) {
-      console.log("#####DECODING RESPONSE#####");
+    if (decoder in decoders) {
       decoders[decoder].call(response, body, callback);
     } else {
-      console.log("#####NO RESPONSE DECODING#####");
       callback(null, body);
     }
   },
@@ -190,13 +193,13 @@ mixin(Request.prototype, {
     }
     return body;
   },
-  _encode: function(body, response, disableDecoding, callback) {
+  _encode: function(body, response, callback) {
     var self = this;
     if (self.options.decoding == 'buffer') {
       callback(null, body);
     } else {
       body = body.toString(self.options.decoding);
-      if (!(disableDecoding === true) && self.options.parser) {
+      if (self.options.parser) {
         self.options.parser.call(response, body, callback);
       } else {
         callback(null, body);

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -147,29 +147,31 @@ mixin(Request.prototype, {
 
       response.on('end', function() {
         response.rawEncoded = body;
-          self._decode(new Buffer(body, 'binary'), response, function(err, body) {
+        self._decode(new Buffer(body, 'binary'), response, self.options.disable_decoding, function(err, body) {
+          if (err) {
+            self._fireError(err, response);
+            return;
+          }
+          response.raw = body;
+          body = self._iconv(body, response);
+          self._encode(body, response, function(err, body) {
             if (err) {
               self._fireError(err, response);
-              return;
+            } else {
+              self._fireSuccess(body, response);
             }
-            response.raw = body;
-            body = self._iconv(body, response);
-            self._encode(body, response, function(err, body) {
-              if (err) {
-                self._fireError(err, response);
-              } else {
-                self._fireSuccess(body, response);
-              }
-            });
           });
+        });
       });
     }
   },
-  _decode: function(body, response, callback) {
+  _decode: function(body, response, disableDecoding, callback) {
     var decoder = response.headers['content-encoding'];
-    if (decoder in decoders) {
+    if (!disableDecoding && decoder in decoders) {
+      console.log("#####DECODING RESPONSE#####");
       decoders[decoder].call(response, body, callback);
     } else {
+      console.log("#####NO RESPONSE DECODING#####");
       callback(null, body);
     }
   },

--- a/lib/restler.js
+++ b/lib/restler.js
@@ -167,7 +167,7 @@ mixin(Request.prototype, {
   },
   _decode: function(body, response, disableDecoding, callback) {
     var decoder = response.headers['content-encoding'];
-    if (!disableDecoding && decoder in decoders) {
+    if (!(disableDecoding === true) && decoder in decoders) {
       console.log("#####DECODING RESPONSE#####");
       decoders[decoder].call(response, body, callback);
     } else {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     "test": "node test/all.js"
   },
   "dependencies": {
+    "compression": "^1.6.2",
+    "express": "^4.14.0",
+    "iconv-lite": "0.2.11",
     "qs": "1.2.0",
     "xml2js": "0.4.0",
-    "yaml": "0.2.3",
-    "iconv-lite": "0.2.11"
+    "yaml": "0.2.3"
   },
   "devDependencies": {
     "nodeunit": "0.8.2"

--- a/test/gzip-test/gzip-client.js
+++ b/test/gzip-test/gzip-client.js
@@ -82,7 +82,7 @@ var getFromTrustedZone = function(url,req,res){
 	var headers = getEnrichedHeaders(req);
 
 
-	rest.get(fullUrl, {headers: headers, disable_decoding: false}).on('complete', function(data, response){_completeFunction(data,response,res,url);});
+	rest.get(fullUrl, {headers: headers, disable_decoding: true}).on('complete', function(data, response){_completeFunction(data,response,res,url);});
 }
 
 // START POINT: //
@@ -90,7 +90,7 @@ var req = new MockExpressRequest();
 var res = new MockExpressResponse();
 
 
-getFromTrustedZone("http://localhost:3000/json",req, res);
+getFromTrustedZone("http://localhost:6969/json",req, res);
 
 
 

--- a/test/gzip-test/gzip-client.js
+++ b/test/gzip-test/gzip-client.js
@@ -82,7 +82,7 @@ var getFromTrustedZone = function(url,req,res){
 	var headers = getEnrichedHeaders(req);
 
 
-	rest.get(fullUrl, {headers: headers, disable_decoding: true}).on('complete', function(data, response){_completeFunction(data,response,res,url);});
+	rest.get(fullUrl, {headers: headers, disable_decoding: false}).on('complete', function(data, response){_completeFunction(data,response,res,url);});
 }
 
 // START POINT: //

--- a/test/gzip-test/gzip-client.js
+++ b/test/gzip-test/gzip-client.js
@@ -1,0 +1,96 @@
+var rest = require('restler');
+var util = require('util');
+var Logger = require('bunyan');
+var log = new Logger({name: 'Backend requests from proxy' /*, ... */});
+var MockExpressRequest = require('mock-express-request');
+var MockExpressResponse = require('mock-express-response');
+/**
+* Convert object with keys & values to url query
+* TODO: error handling & callbacks
+*/
+var objectToURLQuery = function(obj){
+	var str = "";
+	Object.keys(obj||{}).forEach(function(key) {
+	    if (str != "") {
+	        str += "&";
+	    }
+	    str += key + "=" + encodeURIComponent(obj[key]);
+	});
+	if(str.length > 0){
+		str = "?" + str;
+	}
+	return str;
+}
+
+var _infoLogger = function(response,data, url){
+				if(responseHasErrors(response) ){
+				log.info("DEBUG (remove this logging in prod) :error: %s,  message: %s, url: %s", data.status, data.message, url);
+			}
+			else if(data.Error){
+				log.info("DEBUG (remove this logging in prod) :error: %s,", data.Error);
+			}
+
+}
+
+var responseHasErrors = function(response){
+	return (response.statusCode == 0 || response.statusCode >299);
+}
+
+var _completeFunction = function(data, responseFromTrustedZone, responseToClient, url, next) {
+
+
+	//Take care of forwarding the headers from trusted backend to the expressjs response:
+	if(responseFromTrustedZone){	
+		Object.keys(responseFromTrustedZone.headers).forEach(function(name) {
+  		responseToClient.setHeader(name, responseFromTrustedZone.headers[name]);
+		});
+
+		_infoLogger(responseFromTrustedZone, data, url);
+
+		responseToClient.statusCode = responseFromTrustedZone.statusCode;
+	}
+	if(data !== void 0 && data !== undefined){
+		log.info(data);
+		responseToClient.send(data);
+	}else{
+		log.info("NO data...");
+
+		responseToClient.send();
+	}
+}
+
+
+/*
+* Helper for enriching the headers
+*
+*/
+var getEnrichedHeaders = function(req){
+		//Extract the requesting user from the token and attach to the headers of the new request:
+	var headers = {}, enrichmentHeaders = {};
+	Object.assign(headers, req.headers, enrichmentHeaders);
+	return headers;
+};
+
+
+/*
+* Proxy method for passing a "get" request from a client to the trusted zone (and the backend).
+* The backend response is returned to the client.
+*/
+var getFromTrustedZone = function(url,req,res){
+	//The full url should be fixed to url + req query
+	var fullUrl = url + objectToURLQuery(req.query);
+	var headers = getEnrichedHeaders(req);
+
+
+	rest.get(fullUrl, {headers: headers, disable_decoding: false}).on('complete', function(data, response){_completeFunction(data,response,res,url);});
+}
+
+// START POINT: //
+var req = new MockExpressRequest();
+var res = new MockExpressResponse();
+
+
+getFromTrustedZone("http://localhost:3000/json",req, res);
+
+
+

--- a/test/gzip-test/gzip-server.js
+++ b/test/gzip-test/gzip-server.js
@@ -18,6 +18,6 @@ app.get('/send', function(req, res) {
 });
 
 app.listen(6969, function () {
-  console.log('Example app listening on port 3000!');
+  console.log('Example app listening on port 6969!');
 });
 

--- a/test/gzip-test/gzip-server.js
+++ b/test/gzip-test/gzip-server.js
@@ -1,0 +1,23 @@
+var compression = require('compression')
+var express = require('express')
+
+var app = express()
+
+
+app.use(express.static(__dirname));
+
+app.use(compression({ threshold: 0 }));
+
+// add all routes
+app.get('/json', function(req, res) {
+  res.json('hello world');
+});
+
+app.get('/send', function(req, res) {
+  res.send('hello world');
+});
+
+app.listen(6969, function () {
+  console.log('Example app listening on port 3000!');
+});
+

--- a/test/gzip-test/index.html
+++ b/test/gzip-test/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>title</title>
+  </head>
+  <body>
+  <button onclick="httpGetAsync();">LOAD</button>
+  
+  </body>
+</html>
+
+
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+
+<script>
+function httpGetAsync()
+{
+    var xmlHttp = new XMLHttpRequest();
+    var theUrl = "http://localhost:6969/json";
+    xmlHttp.onreadystatechange = function() { 
+        if (xmlHttp.readyState == 4 && xmlHttp.status == 200)
+            console.log(xmlHttp.responseText);
+    }
+    xmlHttp.open("GET", theUrl, true); // true for asynchronous 
+    xmlHttp.send(null);
+}
+	</script>

--- a/test/gzip-test/package.json
+++ b/test/gzip-test/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "gzip-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "gzip-client.js",
+  "scripts": {
+    "test": "concurrently --kill-others 'node gzip-server.js' 'node gzip-client.js'"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bunyan": "^1.8.1",
+    "compression": "^1.6.2",
+    "concurrently": "^2.2.0",
+    "express": "^4.14.0",
+    "lodash": "^3.10.1",
+    "mock-express-request": "^0.1.1",
+    "mock-express-response": "^0.1.2",
+    "mocks": "0.0.15",
+    "restler": "git+https://github.com/devdavidkarlsson/restler.git"
+  }
+}


### PR DESCRIPTION
When using RESTLER as HTTP-lib in a proxy application I don't want the responses to be decoded in the proxy, just passed through, hence I need to disable decoding.
