### PR TITLE
Stringify octal number to make compatible with strict mode

### DIFF
--- a/lib/multipartform.js
+++ b/lib/multipartform.js
@@ -109,7 +109,7 @@ Part.prototype = {
 	
   	//Now write out the body of the Part
     if (this.value instanceof File) {
-  	  fs.open(this.value.path, "r", 0666, function (err, fd) { 
+  	  fs.open(this.value.path, "r", "0666", function (err, fd) { 
     	  if (err) throw err; 
     	  
   		  var position = 0;


### PR DESCRIPTION
The octal numbers used are not compatible when using this module in strict mode.
So I have to change it manually everytime I do a `npm install` on a different machine. Would be possible for you to merge this.
