### PR TITLE
Upgrade qs library

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "node test/all.js"
   },
   "dependencies": {
-    "qs": "1.2.0",
+    "qs": "6.4.0",
     "xml2js": "0.4.0",
     "yaml": "0.2.3",
     "iconv-lite": "0.2.11"


### PR DESCRIPTION
I was getting the following error:
```
TypeError: obj.hasOwnProperty is not a function
    at Object.module.exports [as stringify] (/xxx/node_modules/restler/node_modules/qs/lib/stringify.js:49:17
```

Upgrading the `qs` library to the latest version solves this issue, as it uses `Object.hasOwnProperty.call()`.