### PR TITLE
If xml2js or yaml will failed we do not know

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -441,7 +441,11 @@ try {
   };
 
   parsers.auto.matchers['application/yaml'] = parsers.yaml;
-} catch(e) {}
+} catch(e) {
+  parsers.yaml = function() {
+    throw Error('yaml parser had not been loaded');
+  }
+}
 
 try {
   var xml2js = require('xml2js');
@@ -461,7 +465,11 @@ try {
   };
 
   parsers.auto.matchers['application/xml'] = parsers.xml;
-} catch(e) { }
+} catch(e) {
+  parsers.xml = function() {
+    throw Error('xml parser had not been loaded');
+  }
+}
 
 var decoders = {
   gzip: function(buf, callback) {


### PR DESCRIPTION
If `xml2js` and `yaml` failed we will not get error and we get some strange errors when we try to call `shortcutOptions`. The function will try to set `parsers.xml.options`. It is wrong.
With this pullrequest all functionality will work and we will get correct error when we try to use XML or YAML.